### PR TITLE
Rename package to soasta-repository add cmd.js as executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "SOASTA JavaScript repository access",
   "main": "lib/model/Repository.js",
   "bin": {
-    "repository": "./cmd.js"
+    "soasta-repository": "./cmd.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will make the repository package on npm stand out as what it is an API interface to SOASTA repository.

This will make us as a company and what the package does more visible to the npm users and not confuse with other repositories that might have npm packages. 

Also flags cmd.js as an executable to be called on the CLI (as it is intended).
