### PR TITLE
Add shebang so shells can directly execute cmd.js

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var program = require("commander");
 var fs = require("fs");
 


### PR DESCRIPTION
With this commit we can directly call ./cmd.js and you bash/zsh/sh/dash will all to the right thing and call node to execute the file. 

Without this line shells interpret this file as a shellscript and error out.
