### PR TITLE
Add `update` call to cli, based on json formatted file

### DIFF
--- a/cli/update.js
+++ b/cli/update.js
@@ -1,0 +1,56 @@
+"use strict";
+
+//
+// Imports
+//
+var log = require("../lib/util/log");
+var cmdCore = require("./core");
+var fs = require("fs");
+var path = require("path");
+//
+// Action
+//
+module.exports = function(type, id, file, options) {
+    cmdCore.init(options);
+
+    var fullPath = path.resolve(file);
+    var jsonObject;
+
+    try {
+        fs.existsSync(fullPath);
+        jsonObject = require(fullPath);
+    }
+    catch(exception) {
+        log.error(exception.message);
+        process.exit(1);
+    }
+
+    cmdCore.connectToRepository(options, function(connectError, repo) {
+        handleError(connectError);
+
+        repo.objectExists(type, id, function(existsError, exists) {
+            handleError(existsError);
+
+            if (exists) {
+                repo.updateObject(type, id, jsonObject, function(updateError, result) {
+                    handleError(updateError);
+                    log.debug(JSON.stringify(result, null, true));
+                    log.info("Update was successful! New Object:");
+                    var object = result.objects[0];
+                    log.info("ID: " + object.id);
+                    log.info("Name: " + object.name);
+                    log.info("New values: " + JSON.stringify(jsonObject));
+                });
+            } else {
+                handleError(new Error("Object of type: " + type + " and id: " + id + " could not be found. Exiting..."));
+            }
+        });
+    });
+};
+
+function handleError (err) {
+    if (err) {
+        log.error(err.message);
+        process.exit(1);
+    }
+}

--- a/cmd.js
+++ b/cmd.js
@@ -20,5 +20,9 @@ program.command("delete <type> <id>")
     .description("delete objects")
     .action(require("./cli/delete.js"));
 
+program.command("update <type> <id> <file>")
+    .description("Update an object in the repository based on the JSON formatted data in a file")
+    .action(require("./cli/update.js"));
+
 // go
 program.parse(process.argv);


### PR DESCRIPTION
Adds an `update` command to cli. Consumes  a JSON formatted file containing the changed item in the 
object we are querying to. 

Calling convention:

```
 $> ./cmd.js update domain 3 file.json
```

Where file.json may contain:

``` json
{
   "name": "New Domain Name!"
}
```

please review: @msolnit 
