### PR TITLE
Add --json flag for JSON formatted output

### DIFF
--- a/cli/core.js
+++ b/cli/core.js
@@ -26,6 +26,13 @@ var SOASTA = require("../lib/model/Repository.js");
  * @param {object} options Options
  */
 exports.init = function(options) {
+
+    if (options && options.parent && typeof options.parent.json === "undefined") {
+        log.transports.console.json =  false;
+    } else {
+        log.transports.console.json =  true;
+    }
+
     if (options && options.parent && options.parent.verbose) {
         log.transports.console.level = "debug";
     }
@@ -43,8 +50,6 @@ exports.init = function(options) {
     if (!options.parent.repository) {
         options.parent.repository = constants.REPOSITORY_URL;
     }
-
-    console.log(options.parent);
 
     // ensure username and password have been specified
     if (!options.parent.username) {

--- a/cmd.js
+++ b/cmd.js
@@ -8,6 +8,7 @@ program
     .option("-p, --password <password>", "Password")
     .option("-t, --tenant <tenant>", "Tenant name")
     .option("-r, --repository <url>", "Repository URL")
+    .option("-j, --json", "Output as JSON")
     .option("-o, --output <file>", "Output file")
     .option("-v, --verbose", "Verbose debugging");
 


### PR DESCRIPTION
Adds `--json` flag to ./cmd.js. Result is JSON formatted output

Usage: 

```
$> ./cmd.js --json query domain | jq '.objects[].name'
"mPulse Demo"
```

Please review: @msolnit @nicjansma 
