### PR TITLE
Resolve package.json properly from cli/cmd.js

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -15,7 +15,7 @@ var path = require("path");
 var fs = require("fs");
 
 program
-    .version(JSON.parse(fs.readFileSync(path.join("package.json"), "utf-8")).version)
+    .version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
     .option("-u, --username <username>", "User name")
     .option("-p, --password <password>", "Password")
     .option("-t, --tenant <tenant>", "Tenant name")


### PR DESCRIPTION
This will help finding package.json from cli/cmd.js if
soasta-repository is called from $PATH

Found this issue when executing cmd.js not from the root directory of the project. This should help us if we intend to install soasta-repository for it's executable somewhere.

please review: @msolnit @nicjansma 