### PR TITLE
Allow for different auth.json to be passed in via options

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -22,7 +22,8 @@ program
     .option("-r, --repository <url>", "Repository URL")
     .option("-j, --json", "Output as JSON")
     .option("-o, --output <file>", "Output file")
-    .option("-v, --verbose", "Verbose debugging");
+    .option("-v, --verbose", "Verbose debugging")
+    .option("-a, --auth <file>", "auth.json file containing credentials");
 
 // commands
 program.command("query <type>")

--- a/cli/core.js
+++ b/cli/core.js
@@ -46,7 +46,7 @@ exports.init = function(options) {
 
     if (fs.existsSync(authJsonPath)) {
         // read in auth info
-        var authContents = fs.readFileSync("auth.json", "utf-8");
+        var authContents = fs.readFileSync(authJsonPath, "utf-8");
         var auth = JSON.parse(authContents);
 
         // use auth contents as fallback

--- a/cli/core.js
+++ b/cli/core.js
@@ -28,6 +28,7 @@ var SOASTA = require("../lib/model/Repository.js");
  * @param {object} options Options
  */
 exports.init = function(options) {
+    var authJsonPath = "auth.json";
 
     if (options && options.parent && typeof options.parent.json === "undefined") {
         log.transports.console.json =  false;
@@ -39,7 +40,11 @@ exports.init = function(options) {
         log.transports.console.level = "debug";
     }
 
-    if (fs.existsSync("auth.json")) {
+    if (options && options.parent && options.parent.auth) {
+        authJsonPath = options.parent.auth;
+    }
+
+    if (fs.existsSync(authJsonPath)) {
         // read in auth info
         var authContents = fs.readFileSync("auth.json", "utf-8");
         var auth = JSON.parse(authContents);


### PR DESCRIPTION
Working with multiple instances of the RepositoryService it's beginning to get fiddly to repoint auth.json
to different API destinations. 

With this PR we can use `--auth <file>` passed in as auth.json file to consume.