### PR TITLE
Add support for apiToken and includeDetails flag on queries

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -25,7 +25,7 @@ program
     .option("-o, --output <file>", "Output file")
     .option("-v, --verbose", "Verbose debugging")
     .option("-a, --auth <file>", "auth.json file containing credentials")
-    .option("-d, --details <boolean>", "Enable/Disable retrieving full objet details")
+    .option("-d, --details <boolean>", "Enable/Disable retrieving full object details")
     .option("-i, --stdin", "Use STDIN if file is required");
 
 // commands

--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -18,17 +18,19 @@ program
     .version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
     .option("-u, --username <username>", "User name")
     .option("-p, --password <password>", "Password")
+    .option("-T, --apitoken <apitoken>", "SSO API Token")
     .option("-t, --tenant <tenant>", "Tenant name")
     .option("-r, --repository <url>", "Repository URL")
     .option("-j, --json", "Output as JSON")
     .option("-o, --output <file>", "Output file")
     .option("-v, --verbose", "Verbose debugging")
     .option("-a, --auth <file>", "auth.json file containing credentials")
+    .option("-d, --details <boolean>", "Enable/Disable retrieving full objet details")
     .option("-i, --stdin", "Use STDIN if file is required");
 
 // commands
-program.command("query <type>")
-    .description("query objects")
+program.command("query <type> [<params>]")
+    .description("query for objects by type with optional parameters (comma separated)")
     .action(require("./query.js"));
 
 program.command("delete <type> <id>")

--- a/cli/core.js
+++ b/cli/core.js
@@ -58,16 +58,18 @@ exports.init = function(options) {
         options.parent.repository = constants.REPOSITORY_URL;
     }
 
+  if (!options.parent.apiToken) {
     // ensure username and password have been specified
     if (!options.parent.username) {
-        log.error("--username (-u) is required");
-        process.exit(1);
+      log.error("--username (-u) is required");
+      process.exit(1);
     }
 
     if (!options.parent.password) {
-        log.error("--password (-p) is required");
-        process.exit(1);
+      log.error("--password (-p) is required");
+      process.exit(1);
     }
+  }
 };
 
 /**
@@ -77,10 +79,17 @@ exports.init = function(options) {
  * @param {function(err, repo)} callback Callback
  */
 exports.connectToRepository = function(options, callback) {
-    var repo = new SOASTA.Repository(options.parent.repository);
-    repo.connect(options.parent.tenant, options.parent.username, options.parent.password, function(err) {
-        return callback && callback(err, repo);
+  var repo = new SOASTA.Repository(options.parent.repository);
+  if (options.parent.apiToken) {
+    repo.connectByApiToken(options.parent.tenantName || null, options.parent.apiToken, function(err) {
+      return callback && callback(err, repo);
     });
+  }
+  else {
+    repo.connect(options.parent.tenant, options.parent.username, options.parent.password, function(err) {
+      return callback && callback(err, repo);
+    });
+  }
 }
 
 /**

--- a/cli/core.js
+++ b/cli/core.js
@@ -58,18 +58,19 @@ exports.init = function(options) {
         options.parent.repository = constants.REPOSITORY_URL;
     }
 
-  if (!options.parent.apiToken) {
-    // ensure username and password have been specified
-    if (!options.parent.username) {
-      log.error("--username (-u) is required");
-      process.exit(1);
+    if (!options.parent.apiToken) {
+        // ensure username and password have been specified
+        if (!options.parent.username) {
+            log.error("--username (-u) is required");
+            process.exit(1);
+        }
+
+        if (!options.parent.password) {
+            log.error("--password (-p) is required");
+            process.exit(1);
+        }
     }
 
-    if (!options.parent.password) {
-      log.error("--password (-p) is required");
-      process.exit(1);
-    }
-  }
 };
 
 /**
@@ -79,17 +80,17 @@ exports.init = function(options) {
  * @param {function(err, repo)} callback Callback
  */
 exports.connectToRepository = function(options, callback) {
-  var repo = new SOASTA.Repository(options.parent.repository);
-  if (options.parent.apiToken) {
-    repo.connectByApiToken(options.parent.tenantName || null, options.parent.apiToken, function(err) {
-      return callback && callback(err, repo);
-    });
-  }
-  else {
-    repo.connect(options.parent.tenant, options.parent.username, options.parent.password, function(err) {
-      return callback && callback(err, repo);
-    });
-  }
+    var repo = new SOASTA.Repository(options.parent.repository);
+    if (options.parent.apiToken) {
+        repo.connectByApiToken(options.parent.tenantName || null, options.parent.apiToken, function(err) {
+            return callback && callback(err, repo);
+        });
+    }
+    else {
+        repo.connect(options.parent.tenant, options.parent.username, options.parent.password, function(err) {
+            return callback && callback(err, repo);
+        });
+    }
 }
 
 /**

--- a/cli/query.js
+++ b/cli/query.js
@@ -16,13 +16,29 @@ var fs = require("fs");
 //
 // Action
 //
-module.exports = function(type, options) {
+module.exports = function(type, params, options) {
+    var queryParams = params || {},
+        includeDetails = true;
+
+    // eg: tenant=1,name="mPulse Demo"
+    if (typeof queryParams === "string") {
+        var matchMultiParam = queryParams.match(/(.*,.*|=)/g);
+
+        if (matchMultiParam && matchMultiParam.length > 1) {
+            queryParams = queryParams.split(",");
+        }
+    }
+
+    if (typeof options.parent.details !== "undefined") {
+        includeDetails = JSON.parse(options.parent.details);
+    }
+
     cmdCore.init(options);
 
     cmdCore.connectToRepository(options, function(err, repo) {
         cmdCore.handleError(err);
 
-        repo.queryObjects(type, {}, function(err, data) {
+        repo.queryObjects(type, queryParams, includeDetails, function(err, data) {
             cmdCore.handleError(err);
 
             if (options.parent.output) {

--- a/lib/model/Objects.js
+++ b/lib/model/Objects.js
@@ -112,25 +112,56 @@ Objects.prototype.objectExists = function(token, type, id, callback) {
  *
  * @param {string} token - API-Auth token retrieved with {@link Tokens}
  * @param {string} type - Type of repository object to search for
- * @param {Object} query - POJO describing attributes to search for in the collection of repository objects
+ * @param {(Object|function|String[])} query - Filter attributes to apply to repository search
+ * @param {bool} includeDetails - Flag if or if not to return full object from query
  * @param {function} callback -
  * [A callback function called after the API request was finalized]{@link Objects~queryObjects(callback)}
  */
-Objects.prototype.queryObjects = function(token, type, query, callback) {
+Objects.prototype.queryObjects = function(token, type, query, includeDetails, callback) {
     log.debug("queryObjects(token=" + token + ", type=" + type + ", query=" + JSON.stringify(query) + ")");
 
-    var queryURL = this.endpoint + "/" + type + "/";
+    if (!callback && typeof includeDetails === "function") {
+        callback = includeDetails;
+    }
 
+    var queryURL = this.endpoint + "/" + type + "/";
     var firstParam = true;
-    for (var name in query) {
-        if (firstParam) {
-            queryURL += "?";
-            firstParam = false;
-        } else {
-            queryURL += "&";
+    
+    if (typeof query === "object") {
+        if (Object.prototype.toString.call(query) === "[object Array]") {
+            queryURL += "?" + query.join("&");
         }
-        var value = query[name];
-        queryURL += name + "=" + encodeURIComponent(value);
+        else {
+
+            for (var name in query) {
+                if (firstParam) {
+                    queryURL += "?";
+                    firstParam = false;
+                } else {
+                    queryURL += "&";
+                }
+                var value = query[name];
+                queryURL += name + "=" + encodeURIComponent(value);
+            }
+        }
+    }
+    else if (typeof query === "function") {
+        var additionalParams = "";
+        try {
+            // keep firstparam true if additionalParams was empty string
+            additionalParams += query();
+            firstParam = additionalParams.length > 0 ? false : true;
+        }
+        catch(error) {}
+        queryURL += additionalParams;
+    }
+    else if (typeof query === "string") {
+        queryURL += (firstParam ? "?" : "&") + query;
+        firstParam = false;
+    }
+
+    if (typeof includeDetails === "boolean" && includeDetails === false) {
+        queryURL += (firstParam ? "?" : "&") + "includeDetails=false";
     }
 
     api(token, queryURL, "GET", null, callback);

--- a/lib/model/Repository.js
+++ b/lib/model/Repository.js
@@ -39,7 +39,6 @@ var SOASTA = {
          * [Called after the API request was finalized]{@link Repository~connect(callback)}
          */
         this.connect = function(tenantName, userName, password, callback) {
-            // Wrap the provided callback with an in-between that extracts the token before proceeding.
             var wrapper = function(error, token) {
                 log.debug("Got token: " + token + " or error: " + error);
                 self.token = token;
@@ -64,6 +63,27 @@ var SOASTA = {
          * Repository instance and used from here on out as a header to inform the server that this client has
          * authenticated successfully
          */
+
+        /**
+         * Authenticate with the API endpoint to get the API-Auth token
+         *
+         * @param {string} tenantName - name of the tenant we want to access
+         * @param {string} apiToken - the apiToken retrieved from mPulse UI
+         * @param {function} callback -
+         * [Called after the API Auth request was finalized]{@link Repository~connect(callback)}
+         */
+        this.connectByApiToken = function(tenantName, apiToken, callback) {
+            var wrapper = function (error, token) {
+                log.debug("Got token: " + token + " or error: " + error);
+                self.token = token;
+
+                if (callback) {
+                    callback(error);
+                }
+            }
+
+            tokens.connectByApiToken(tenantName, apiToken, wrapper);
+        };
 
         /**
          * See [createObject in Objects]{@link Objects#createObject}. The {@link token} will be passed on directly
@@ -104,12 +124,13 @@ var SOASTA = {
          * See [queryObjects in Objects]{@link Objects#queryObjects}. The {@link token} will be passed on directly
          *
          * @param {string} type - Type of repository object to search for
-         * @param {Object} query - POJO describing attributes to search for in the collection of repository objects
+         * @param {(Object|function|String[])} query - Filter attributes to apply to repository search
+         * @param {bool} includeDetails - Flag if or if not to return full object from query
          * @param {function} callback -
          * [Called after the API request was finalized]{@link Objects~queryObjects(callback)}
          */
-        this.queryObjects = function(type, query, callback) {
-            objects.queryObjects(self.token, type, query, callback);
+        this.queryObjects = function(type, query, includeDetails, callback) {
+            objects.queryObjects(self.token, type, query, includeDetails, callback);
         };
 
         /**

--- a/lib/model/Tokens.js
+++ b/lib/model/Tokens.js
@@ -20,7 +20,7 @@ function Tokens(serviceUrl) {
 }
 
 /**
- * Authenticate with the API endpoint af bet the API-Auth token
+ * Authenticate with the API endpoint to get the API-Auth token
  *
  * @param {string} tenantName - name of the tenant we want to access
  * @param {string} userName - the username we want to authenticate with
@@ -61,6 +61,40 @@ Tokens.prototype.connect = function(tenantName, userName, password, callback) {
  * @param {?Error} err - {@link null} or an Error object describing the type of Exception thrown by the authentication
  * @param {?string} token - Authentication token returned upon successfull authentication
  */
+
+/**
+ * Authenticate with the API endpoint to get the API-Auth token
+ *
+ * @param {string} tenantName - name of the tenant we want to access
+ * @param {string} apiToken - the apiToken retrieved from mPulse UI
+ * @param {function} callback -
+ * [Called after the API Auth request was finalized]{@link Tokens~connect(callback)}
+ */
+Tokens.prototype.connectByApiToken = function(tenantName, apiToken, callback)
+{
+	var credentials = {
+        apiToken: apiToken
+    };
+
+    if (tenantName) {
+        credentials.tenant = tenantName;
+    }
+
+	api(null, this.endpoint, "PUT", credentials, function(error, responseBody) {
+        if (error) {
+            // Request failed.
+            callback(error, null);
+        } else {
+            // Success!
+
+            // Response JSON will look like:
+            // { "token": "<random string>" }
+
+            // Extract the actual token and return that in the callback.
+            callback(null, responseBody.token);
+        }
+    });
+}
 
 /**
  * Disconnect or deauthenticate from the repository API endpoint effectively invalidating the token


### PR DESCRIPTION
## CLI
Adds `-T, --apitoken <apitoken>` flag to provide an optional apiToken instead of username/password

Adds `-d, --details <boolean>` flag to enable/disable retrieving a detailed response from the server for Objects when querying

## API
Adds `connectByApiToken(tenantName, apiToken, callback)` to use a apiToken and optional tenant as authentication method

Extends `queryObjects(type, query, includeDetails, callback)` supporting includeDetails as flag to the query function. If not provided will use 3rd param as callback if it's a function
