### PR TITLE
If query is an array and has values flag firstParam = false

### DIFF
--- a/lib/model/Objects.js
+++ b/lib/model/Objects.js
@@ -122,14 +122,18 @@ Objects.prototype.queryObjects = function(token, type, query, includeDetails, ca
 
     if (!callback && typeof includeDetails === "function") {
         callback = includeDetails;
+        includeDetails = null;
     }
 
     var queryURL = this.endpoint + "/" + type + "/";
     var firstParam = true;
-    
+
     if (typeof query === "object") {
         if (Object.prototype.toString.call(query) === "[object Array]") {
-            queryURL += "?" + query.join("&");
+            if (query.length > 0 ) {
+                queryURL += "?" + query.join("&");
+                firstParam = false;
+            }
         }
         else {
 


### PR DESCRIPTION
Fixes issue if we pass an array of the same values when running queries
