### PR TITLE
fixes incorrect return statement outside of function

### DIFF
--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -3,7 +3,7 @@
 // cheap and dirty way to see if we're in a web context
 var logger;
 if (typeof window !== undefined && window.console) {
-    log = window.console;
+    logger = window.console;
 } else {
     var winston = require("winston");
 

--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -1,32 +1,33 @@
 "use strict";
 
 // cheap and dirty way to see if we're in a web context
+var logger;
 if (typeof window !== undefined && window.console) {
     log = window.console;
-    return;
+} else {
+    var winston = require("winston");
+
+    var isDebug = process.env.DEBUG;
+
+    logger = new (winston.Logger)({
+        transports: [
+            new (winston.transports.Console)({
+                level: isDebug ? "debug" : "info"
+            })
+        ]
+    });
+
+    // set log levels
+    logger.setLevels({
+        emerg: 7,
+        alert: 6,
+        crit: 5,
+        error: 4,
+        warning: 3,
+        notice: 2,
+        info: 1,
+        debug: 0
+    });
+
+    module.exports = logger;
 }
-var winston = require("winston");
-
-var isDebug = process.env.DEBUG;
-
-var logger = new (winston.Logger)({
-    transports: [
-        new (winston.transports.Console)({
-            level: isDebug ? "debug" : "info"
-        })
-    ]
-});
-
-// set log levels
-logger.setLevels({
-    emerg: 7,
-    alert: 6,
-    crit: 5,
-    error: 4,
-    warning: 3,
-    notice: 2,
-    info: 1,
-    debug: 0
-});
-
-module.exports = logger;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soasta-repository",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "SOASTA JavaScript repository access",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Used return statement outside of a function as a shortcut which didn't compile with react-flow.

Also it seems like the change to logger was using the improper variable name "log" which is also fixed