### PR TITLE
Compare with string as typeof returns a string value

### DIFF
--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -2,7 +2,7 @@
 
 // cheap and dirty way to see if we're in a web context
 var logger;
-if (typeof window !== undefined && window.console) {
+if (typeof window !== "undefined" && window.console) {
     logger = window.console;
 } else {
     var winston = require("winston");


### PR DESCRIPTION
Found this bug when trying to run soasta-repository from the CLI:
```
/Users/amarschke/src/js/repository.js/repository.js/lib/util/log.js:5
if (typeof window !== undefined && window.console) {
                                         ^

TypeError: Cannot read property 'console' of undefined
    at Object.<anonymous> (/Users/amarschke/src/js/repository.js/repository.js/lib/util/log.js:5:42)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/amarschke/src/js/repository.js/repository.js/cli/query.js:12:11)
    at Module._compile (module.js:571:32)
```

`typeof` returns a string value of the type of the value checked. meaning `typeof window !== undefined` will always yield true as the return value of `typeof window` is `"undefined"` (string) not `undefined`(primitive type undefined).

This change fixes the use-case for CLI with repository.js

Please review @msolnit @nicjansma @bobbykritzer 